### PR TITLE
fix envoy server not running

### DIFF
--- a/adapter/server/http.go
+++ b/adapter/server/http.go
@@ -45,6 +45,7 @@ func NewHttpServer(
 
 	return &httpServer{
 		server: mux,
+		config: config,
 	}
 }
 

--- a/adapter/server/http.go
+++ b/adapter/server/http.go
@@ -19,7 +19,7 @@ type (
 	}
 
 	httpServer struct {
-		server http.Handler
+		server *runtime.ServeMux
 		config configuration.Config
 	}
 )
@@ -27,29 +27,29 @@ type (
 func NewHttpServer(
 	config configuration.Config,
 ) HttpServer {
+	return &httpServer{
+		server: runtime.NewServeMux(),
+		config: config,
+	}
+}
+
+func (s *httpServer) Serve() error {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	mux := runtime.NewServeMux()
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(
 			insecure.NewCredentials(),
 		),
 	}
 
-	if err := pb.RegisterBazelGrpcGatewayPracticeServiceHandlerFromEndpoint(ctx, mux, ":"+config.Grpc.ServerPort, opts); err != nil {
+	log.Info().Msgf("listen gRPC port: %s", s.config.Grpc.ServerPort)
+	if err := pb.RegisterBazelGrpcGatewayPracticeServiceHandlerFromEndpoint(ctx, s.server, ":"+s.config.Grpc.ServerPort, opts); err != nil {
 		log.Error().Stack().Caller().Err(err)
 		panic(err)
 	}
 
-	return &httpServer{
-		server: mux,
-		config: config,
-	}
-}
-
-func (s *httpServer) Serve() error {
 	log.Info().Msgf("HTTP port: %s", s.config.Http.ServerPort)
 	if err := http.ListenAndServe(":"+s.config.Http.ServerPort, s.server); err != nil {
 		log.Error().Stack().Caller().Err(err)

--- a/cmd/envoy/BUILD.bazel
+++ b/cmd/envoy/BUILD.bazel
@@ -3,15 +3,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "inject.go",
         "main.go",
+        "wire_gen.go",
     ],
     importpath = "github.com/Pranc1ngPegasus/bazel-grpc-gateway-practice/cmd/envoy",
     visibility = ["//visibility:private"],
     deps = [
         "//adapter/configuration:go_default_library",
         "//adapter/server:go_default_library",
-        "@com_github_google_wire//:go_default_library",
         "@com_github_rs_zerolog//log:go_default_library",
     ],
 )

--- a/cmd/envoy/inject.go
+++ b/cmd/envoy/inject.go
@@ -1,4 +1,5 @@
-//go:generate go run github.com/google/wire/cmd/wire
+//go:build wireinject
+// +build wireinject
 
 package main
 


### PR DESCRIPTION
- ignore wire.go on build
- export config to struct
- gRPCエンドポイントのlistenをサーバ起動時に移動した
