### PR TITLE
add rules docker

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ endif
 resolve-dependencies: proto-clean
 	bazelisk run //:buildifier
 	bazelisk run //:gazelle
+
+.PHONY: update-go-dependencies
+update-go-dependencies:
+	go mod tidy
 	bazelisk run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%go_dependencies
 
 .PHONY: proto-clean

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 # rules_go: https://github.com/bazelbuild/rules_go
 http_archive(
@@ -81,6 +81,13 @@ container_repositories()
 container_deps()
 
 _go_image_repos()
+
+# grpc health probe
+http_file(
+    name = "grpc_health_probe",
+    downloaded_file_path = "grpc_health_probe",
+    urls = ["https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.11/grpc_health_probe-linux-amd64"],
+)
 
 ############################################################
 # Define your own dependencies here using go_repository.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,7 +26,15 @@ http_archive(
     ],
 )
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+go_repository(
+    name = "org_golang_google_grpc",
+    build_file_proto_mode = "disable",
+    importpath = "google.golang.org/grpc",
+    sum = "h1:NEpgUqV3Z+ZjkqMsxMg11IaDrXY4RY6CQukSGK0uI1M=",
+    version = "v1.45.0",
+)
 
 gazelle_dependencies()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# rules_go: https://github.com/bazelbuild/rules_go
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "ab21448cef298740765f33a7f5acee0607203e4ea321219f2a4c85a6e0fb0a27",
@@ -9,6 +10,13 @@ http_archive(
     ],
 )
 
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_register_toolchains(version = "1.18")
+
+go_rules_dependencies()
+
+# gazelle: https://github.com/bazelbuild/bazel-gazelle
 http_archive(
     name = "bazel_gazelle",
     sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
@@ -18,6 +26,11 @@ http_archive(
     ],
 )
 
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+# rules_proto: https://github.com/bazelbuild/rules_proto
 http_archive(
     name = "rules_proto",
     sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
@@ -28,8 +41,6 @@ http_archive(
     ],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
 rules_proto_dependencies()
@@ -46,9 +57,3 @@ load("//:deps.bzl", "go_dependencies")
 
 # gazelle:repository_macro deps.bzl%go_dependencies
 go_dependencies()
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.18")
-
-gazelle_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,6 +47,33 @@ rules_proto_dependencies()
 
 rules_proto_toolchains()
 
+# rules_docker: https://github.com/bazelbuild/rules_docker
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "27d53c1d646fc9537a70427ad7b034734d08a9c38924cc6357cc973fed300820",
+    strip_prefix = "rules_docker-0.24.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.24.0/rules_docker-v0.24.0.tar.gz"],
+)
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+load(
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
+)
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_image_repos = "repositories",
+)
+
+container_repositories()
+
+container_deps()
+
+_go_image_repos()
+
 ############################################################
 # Define your own dependencies here using go_repository.
 # Else, dependencies declared by rules_go/gazelle will be used.

--- a/adapter/server/BUILD.bazel
+++ b/adapter/server/BUILD.bazel
@@ -18,5 +18,6 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials/insecure:go_default_library",
         "@org_golang_google_grpc//keepalive:go_default_library",
+        "@org_golang_google_grpc//reflection:go_default_library",
     ],
 )

--- a/adapter/server/grpc.go
+++ b/adapter/server/grpc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/reflection"
 )
 
 type (
@@ -49,6 +50,8 @@ func NewGrpcServer(
 	)
 
 	userV1.RegisterUserServiceServer(server, userServiceV1)
+
+	reflection.Register(server)
 
 	return &grpcServer{
 		server: server,

--- a/cmd/envoy/BUILD.bazel
+++ b/cmd/envoy/BUILD.bazel
@@ -1,4 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_library(
     name = "go_default_library",
@@ -18,5 +21,31 @@ go_library(
 go_binary(
     name = "envoy",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "tar",
+    srcs = ["@grpc_health_probe//file"],
+    mode = "0o755",
+    package_dir = "/bin",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "base_image",
+    base = "@go_image_base//image",
+    docker_run_flags = "-p 3000:3000",
+    tars = [":tar"],
+    visibility = ["//visibility:public"],
+)
+
+go_image(
+    name = "image",
+    base = "base_image",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
     visibility = ["//visibility:public"],
 )

--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -1,4 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_library(
     name = "go_default_library",
@@ -22,5 +25,30 @@ go_library(
 go_binary(
     name = "server",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "tar",
+    srcs = ["@grpc_health_probe//file"],
+    mode = "0o755",
+    package_dir = "/bin",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "base_image",
+    base = "@go_image_base//image",
+    tars = [":tar"],
+    visibility = ["//visibility:public"],
+)
+
+go_image(
+    name = "image",
+    base = "base_image",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
- cleanup WORKSPACE
- add rules_docker
- divide update-go-dependencies make
- disable build_file_proto_mode of google.golang.org/grpc package
- 各サービスがDockerでビルドできるようにした
- grpc reflectionを有効にした
